### PR TITLE
Add package `bussproofs`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN tlmgr install --no-persistent-downloads \
       fontaxes boondox everyhook svn-prov framed subfiles titlesec \
       tocdata xpatch etoolbox l3packages \
       biblatex pbibtex-base logreq biber import environ trimspaces tcolorbox \
-      ebgaramond algorithms algorithmicx xstring siunitx
+      ebgaramond algorithms algorithmicx xstring siunitx bussproofs
 
 # EBGaramond
 RUN cp /usr/share/fonts/opentype/ebgaramond/EBGaramond12-Regular.otf /usr/share/fonts/opentype/EBGaramond.otf && \


### PR DESCRIPTION
## 概要

自分が 51 号で Coq 関連の記事を書くにあたり、証明図を記事の中に埋めたい需要が発生したものの、そのために利用したいパッケージを `usepackage` したら `bussproofs.sty` が無いと言われてしまったので追加します。

## 動作確認

* ローカルでの Docker build が通ること
* 手元でビルドしたイメージを用いて `bussproofs` パッケージを利用した記事のビルドが通ること