### PR TITLE
Add package `enumitem`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN tlmgr install --no-persistent-downloads \
       fontaxes boondox everyhook svn-prov framed subfiles titlesec \
       tocdata xpatch etoolbox l3packages \
       biblatex pbibtex-base logreq biber import environ trimspaces tcolorbox \
-      ebgaramond algorithms algorithmicx xstring siunitx bussproofs
+      ebgaramond algorithms algorithmicx xstring siunitx bussproofs enumitem
 
 # EBGaramond
 RUN cp /usr/share/fonts/opentype/ebgaramond/EBGaramond12-Regular.otf /usr/share/fonts/opentype/EBGaramond.otf && \


### PR DESCRIPTION
## 概要

@inaniwaudon が 52 号で記事を書くにあたり、そのために利用したいパッケージ `enumitem` を `usepackage` したら `enumitem.sty` が無いと言われてしまったので追加します。

## 動作確認

* ローカルでの Docker build が通ること
* 手元でビルドしたイメージを用いて `enumitem` パッケージを利用した記事のビルドが通ること