### PR TITLE
色々修正した

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -41,6 +46,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install docker
-          colima start
+          brew install colima
+          LIMACTL_PATH=$(brew --prefix)/bin/limactl
+          sudo curl -L -o $LIMACTL_PATH https://github.com/mikekazakov/lima-nohvf/raw/master/limactl && sudo chmod +x $LIMACTL_PATH
+          colima start --network-address --arch arm64 --vm-type=qemu
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,15 @@ name: CI
 jobs:
   build-image:
     name: Build and push image
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+          - os: macos-latest
+            platform: linux/arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Docker and start Colima on macOS
-        if: matrix.os == '"macos-latest"'
+        if: matrix.os == 'macos-latest'
         run: |
           brew install docker
           brew install colima

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Docker and start Colima on macOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == '"macos-latest"'
         run: |
           brew install docker
           brew install colima

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Docker and start Colima on macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install docker
+          colima start
+
       - uses: actions/checkout@v4
 
       - name: Docker meta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
   build-image:
     name: Build and push image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +38,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: ${{ matrix.platform }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3
@@ -46,7 +52,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,13 +57,10 @@ RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
 
 # ENV PATH $TEXLIVE_PATH/bin/x86_64-linux:$TEXLIVE_PATH/bin/aarch64-linux:$PATH
 
-COPY --from=registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-11-10-small /usr/local/texlive /usr/local/texlive
+COPY --from=registry.gitlab.com/islandoftex/images/texlive:small /usr/local/texlive /usr/local/texlive
 
 RUN echo "Set PATH to $PATH" && \
     $(find /usr/local/texlive -name tlmgr) path add
-
-ENV TEX_LIVE_VERSION="2024"
-ENV PATH="/usr/local/texlive/$TEX_LIVE_VERSION/bin/$TEX_LIVE_ARCH:$PATH"
 
 # tlmgr section
 RUN tlmgr update --self
@@ -75,7 +72,8 @@ RUN tlmgr install --no-persistent-downloads \
       fontaxes boondox everyhook svn-prov framed subfiles titlesec \
       tocdata xpatch etoolbox l3packages \
       biblatex pbibtex-base logreq biber import environ trimspaces tcolorbox \
-      ebgaramond algorithms algorithmicx xstring siunitx bussproofs enumitem
+      ebgaramond algorithms algorithmicx xstring siunitx bussproofs enumitem && \
+    tlmgr path add
 
 # EBGaramond
 RUN cp /usr/share/fonts/opentype/ebgaramond/EBGaramond12-Regular.otf "/usr/share/fonts/opentype/EB Garamond.otf" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM base AS build-amd64
 ENV AWS_CLI_ARCH linux-x86_64
 ENV TEX_LIVE_ARCH x86_64-linux
 
+FROM build-${TARGETARCH}
+
 # WORD内部向けコンテナなので、何か問題が有ったらSlack上で通知して下さい。
 LABEL maintainer="Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV TEX_LIVE_ARCH x86_64-linux
 FROM build-${TARGETARCH}
 
 # WORD内部向けコンテナなので、何か問題が有ったらSlack上で通知して下さい。
-LABEL maintainer="Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
+LABEL maintainer "Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
 
 ENV PERSISTENT_DEPS \
     tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM ubuntu:noble AS base
 ARG TARGETARCH
 
 FROM base AS build-arm64
-ENV PLATFORM aarch64-linux
+ENV AWS_CLI_ARCH linux-aarch64
+ENV TEX_LIVE_ARCH aarch64-linux
 
 FROM base AS build-amd64
-ENV PLATFORM x86_64-linux
+ENV AWS_CLI_ARCH linux-x86_64
+ENV TEX_LIVE_ARCH x86_64-linux
 
 # WORD内部向けコンテナなので、何か問題が有ったらSlack上で通知して下さい。
 LABEL maintainer="Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
@@ -31,7 +33,7 @@ RUN apt-get update && \
     tzdata $PERSISTENT_DEPS
 
 # install awscliv2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm -r ./aws awscliv2.zip
@@ -73,7 +75,7 @@ RUN echo "Set PATH to $PATH" && \
     $(find /usr/local/texlive -name tlmgr) path add
 
 ENV TEX_LIVE_VERSION 2024
-ENV PATH /usr/local/texlive/$TEX_LIVE_VERSION/bin/$PLATFORM:$PATH
+ENV PATH /usr/local/texlive/$TEX_LIVE_VERSION/bin/$TEX_LIVE_ARCH:$PATH
 
 # tlmgr section
 RUN tlmgr update --self

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,32 +2,19 @@ FROM ubuntu:noble AS base
 ARG TARGETARCH
 
 FROM base AS build-arm64
-ENV AWS_CLI_ARCH linux-aarch64
-ENV TEX_LIVE_ARCH aarch64-linux
+ENV AWS_CLI_ARCH=linux-aarch64
+ENV TEX_LIVE_ARCH=aarch64-linux
 
 FROM base AS build-amd64
-ENV AWS_CLI_ARCH linux-x86_64
-ENV TEX_LIVE_ARCH x86_64-linux
+ENV AWS_CLI_ARCH=linux-x86_64
+ENV TEX_LIVE_ARCH=x86_64-linux
 
 FROM build-${TARGETARCH}
 
 # WORD内部向けコンテナなので、何か問題が有ったらSlack上で通知して下さい。
-LABEL maintainer "Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
+LABEL maintainer="Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
 
-ENV PERSISTENT_DEPS \
-    tar \
-    fontconfig \
-    unzip \
-    wget \
-    curl \
-    make \
-    perl \
-    ghostscript \
-    bash \
-    git \
-    groff \
-    less \
-    fonts-ebgaramond
+ENV PERSISTENT_DEPS="tar fontconfig unzip wget curl make perl ghostscript bash git groff less fonts-ebgaramond"
 
 # キャッシュ修正とパッケージインストールは同時にやる必要がある
 RUN apt-get update && \
@@ -40,11 +27,10 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-$AWS_CLI_ARCH.zip" -o "awscliv
     ./aws/install && \
     rm -r ./aws awscliv2.zip
 
-ENV FONT_URLS \
-    https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.zip \
+ENV FONT_URLS="https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.zip \
     https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJP.zip \
-    https://github.com/adobe-fonts/source-han-serif/raw/release/SubsetOTF/SourceHanSerifJP.zip
-ENV FONT_PATH /usr/share/fonts/
+    https://github.com/adobe-fonts/source-han-serif/raw/release/SubsetOTF/SourceHanSerifJP.zip"
+ENV FONT_PATH="/usr/share/fonts/"
 RUN mkdir -p $FONT_PATH && \
       wget $FONT_URLS && \
       unzip -j "*.zip" "*.otf" -d $FONT_PATH && \
@@ -76,8 +62,8 @@ COPY --from=registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-11-10-sma
 RUN echo "Set PATH to $PATH" && \
     $(find /usr/local/texlive -name tlmgr) path add
 
-ENV TEX_LIVE_VERSION 2024
-ENV PATH /usr/local/texlive/$TEX_LIVE_VERSION/bin/$TEX_LIVE_ARCH:$PATH
+ENV TEX_LIVE_VERSION="2024"
+ENV PATH="/usr/local/texlive/$TEX_LIVE_VERSION/bin/$TEX_LIVE_ARCH:$PATH"
 
 # tlmgr section
 RUN tlmgr update --self
@@ -97,9 +83,9 @@ RUN cp /usr/share/fonts/opentype/ebgaramond/EBGaramond12-Regular.otf "/usr/share
     luaotfload-tool --update
 
 # Install Pandoc
-ENV PANDOC_VERSION 3.5
-ENV PANDOC_DOWNLOAD_URL https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-linux-$TARGETARCH.tar.gz
-ENV PANDOC_ROOT /usr/local/bin/pandoc
+ENV PANDOC_VERSION="3.5"
+ENV PANDOC_DOWNLOAD_URL="https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-linux-$TARGETARCH.tar.gz"
+ENV PANDOC_ROOT="/usr/local/bin/pandoc"
 RUN wget -qO- "$PANDOC_DOWNLOAD_URL" | tar -xzf - && \
     cp pandoc-$PANDOC_VERSION/bin/pandoc $PANDOC_ROOT && \
     rm -Rf pandoc-$PANDOC_VERSION/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ ENV FONT_URLS="https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/
     https://github.com/adobe-fonts/source-han-serif/raw/release/SubsetOTF/SourceHanSerifJP.zip"
 ENV FONT_PATH="/usr/share/fonts/"
 RUN mkdir -p $FONT_PATH && \
-      wget $FONT_URLS && \
-      unzip -j "*.zip" "*.otf" -d $FONT_PATH && \
-      rm *.zip && \
-      fc-cache -f -v
+    wget $FONT_URLS && \
+    unzip -j "*.zip" "*.otf" -d $FONT_PATH && \
+    rm *.zip && \
+    fc-cache -f -v
 
 RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo 'Asia/Tokyo' > /etc/timezone
@@ -57,7 +57,7 @@ RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
 
 # ENV PATH $TEXLIVE_PATH/bin/x86_64-linux:$TEXLIVE_PATH/bin/aarch64-linux:$PATH
 
-COPY --from=registry.gitlab.com/islandoftex/images/texlive:small /usr/local/texlive /usr/local/texlive
+COPY --from=registry.gitlab.com/islandoftex/images/texlive:latest-small /usr/local/texlive /usr/local/texlive
 
 RUN echo "Set PATH to $PATH" && \
     $(find /usr/local/texlive -name tlmgr) path add

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM base AS build-amd64
 ENV PLATFORM x86_64-linux
 
 # WORD内部向けコンテナなので、何か問題が有ったらSlack上で通知して下さい。
-LABEL MAINTAINER="Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
+LABEL maintainer="Totsugekitai <37617413+Totsugekitai@users.noreply.github.com>"
 
 ENV PERSISTENT_DEPS \
     tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-$AWS_CLI_ARCH.zip" -o "awscliv
     rm -r ./aws awscliv2.zip
 
 ENV FONT_URLS="https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.zip \
-    https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJP.zip \
-    https://github.com/adobe-fonts/source-han-serif/raw/release/SubsetOTF/SourceHanSerifJP.zip"
+      https://github.com/adobe-fonts/source-han-sans/releases/latest/download/SourceHanSansJP.zip \
+      https://github.com/adobe-fonts/source-han-serif/raw/release/SubsetOTF/SourceHanSerifJP.zip"
 ENV FONT_PATH="/usr/share/fonts/"
 RUN mkdir -p $FONT_PATH && \
     wget $FONT_URLS && \


### PR DESCRIPTION
-  baseイメージを`ubuntu:noble`に変更
- `pandoc`を`3.5`に更新
- `EBGaramond12-Regular.otf`を`EB Garamond.otf`にコピーしてCIが落ちないようにした
- TeXLiveを公式のDockerイメージから取得するようにした(これでかなり時短できるはず)
- arm64対応